### PR TITLE
Andle/recursive movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,6 @@ Our levels are themed after areas on the UCSD campus. The game currently has lev
 In our game, the player controls a raccoon which occupies one grid cell and is able to move either up, right, down, or left, one grid space at a time. Each level contains at least one piece of trash placed within a grid cell and another grid cell marked as a stash. The objective is to push the trash into the stash grid square to clear the level. The player can push an object to an adjacent cell by moving into the object from the opposite side. Players cannot pull objects, move them diagonally, or move more than one square at a time. Some grid spaces contain walls which are spaces the player and other objects cannot occupy or move through. 
 
 A player has a limited number of “redoes” per level that allow them to undo a movement they have just made. A player also has the ability to reset the state of a level entirely.
+
+# Installation
+To run the tests, run the command `stack test` in a terminal.

--- a/src/Game.hs
+++ b/src/Game.hs
@@ -1,6 +1,4 @@
--- UI, event handlers 
-{-# LANGUAGE OverloadedStrings #-}
-
+-- The main file for the interface between the underlying game and Brick.
 module Game where 
 
 import Data.Matrix 

--- a/src/Sokoban.hs
+++ b/src/Sokoban.hs
@@ -1,4 +1,4 @@
--- Data types, world rules
+-- The main file for the underlying logic of the game.
 module Sokoban
 (
     GameObject(..),
@@ -6,17 +6,17 @@ module Sokoban
     Cell(..),
     Environment,
     Movement(..),
+    MoveStatus(..),
     move,
     sampleLevel,
     emptyCell,
     playerCell,
     wallCell,
     trashCell,
-    isValidMove
+    isValidMove,
 )
     where
 import Data.Matrix
-import Data.List
 import qualified Data.Vector (length) 
 import qualified Data.Ix (inRange)
 
@@ -120,8 +120,6 @@ isValidMove mv loc env = if boundsCheck then ValidMov else InvalidMov
     where 
         destLoc = getLocationAfterMovement mv loc  
         destCell = getCellAtLocation destLoc env
-        nextDestLoc = getLocationAfterMovement mv destLoc 
-        nextDestCell = getCellAtLocation nextDestLoc
         boundsCheck = (isWithinEnvironment loc env) && 
                       (isWithinEnvironment destLoc env) && 
                       (not (containsWall destCell)) && 

--- a/src/Sokoban.hs
+++ b/src/Sokoban.hs
@@ -1,189 +1,234 @@
 -- The main file for the underlying logic of the game.
 module Sokoban
-(
-    GameObject(..),
-    Background(..),
-    Cell(..),
-    Environment,
-    Movement(..),
-    MoveStatus(..),
-    move,
-    sampleLevel,
-    emptyCell,
-    playerCell,
-    wallCell,
-    trashCell,
-    isValidMove,
-)
-    where
-import Data.Matrix
-import qualified Data.Vector (length) 
-import qualified Data.Ix (inRange)
+  ( GameObject(..)
+  , Background(..)
+  , Cell(..)
+  , Environment
+  , Movement(..)
+  , MoveStatus(..)
+  , move
+  , sampleLevel
+  , emptyCell
+  , playerCell
+  , wallCell
+  , trashCell
+  , stashCell
+  , isValidMove
+  ) where
 
+import qualified Data.Ix (inRange)
+import Data.Matrix
+import qualified Data.Vector (length)
 
 -- An object that the player can interact with in the game
-data GameObject = Player | Trash | Wall | Empty 
-    deriving (Eq, Show)
+data GameObject
+  = Player
+  | Trash
+  | Wall
+  | Empty
+  deriving (Eq, Show)
 
 -- The appearance of a grid cell
-data Background = Trashcan | Stash | EmptyBG
-    deriving (Eq, Show)
+data Background
+  = Trashcan
+  | Stash
+  | EmptyBG
+  deriving (Eq, Show)
 
 -- An individual cell within a level, consisting of both a GameObject and a Background
-data Cell = Cell {
-    gameObject :: GameObject,
-    background :: Background
-}
-    deriving (Eq)
+data Cell =
+  Cell
+    { gameObject :: GameObject
+    , background :: Background
+    }
+  deriving (Eq)
 
 -- Override default show for Cells to make display more compact.
-instance Show Cell where 
-    show (Cell gameObject background) = show gameObject ++ ":" ++ show background
+instance Show Cell where
+  show (Cell gameObject background) = show gameObject ++ ":" ++ show background
 
 -- The representation of an individual level
 type Environment = Matrix Cell
 
 -- The types of valid moves
-data Movement = UpMv | RightMv | DownMv | LeftMv 
-    deriving (Eq, Show)
+data Movement
+  = UpMv
+  | RightMv
+  | DownMv
+  | LeftMv
+  deriving (Eq, Show)
 
 -- This could be replaced with a Boolean type, but 
 -- we may add other MoveStatuses in the future.
-data MoveStatus = ValidMov | InvalidMov
-    deriving (Eq, Show)
+data MoveStatus
+  = ValidMov
+  | InvalidMov
+  deriving (Eq, Show)
 
 -- Represents a (row, column) index in an Environment
 type Location = (Int, Int)
 
 -- level building
 emptyCell :: Cell -- just for shorter code
-emptyCell = Cell {gameObject=Empty, background=EmptyBG}
+emptyCell = Cell {gameObject = Empty, background = EmptyBG}
 
 playerCell :: Cell -- cell with player
-playerCell = Cell {gameObject=Player, background=EmptyBG}
+playerCell = Cell {gameObject = Player, background = EmptyBG}
 
 wallCell :: Cell -- a wall
-wallCell = Cell {gameObject=Wall, background=EmptyBG}
+wallCell = Cell {gameObject = Wall, background = EmptyBG}
 
 trashcanCell :: Cell -- starting point of the trash
-trashcanCell = Cell {gameObject=Trash, background=Trashcan}
+trashcanCell = Cell {gameObject = Trash, background = Trashcan}
 
 trashCell :: Cell -- a cell containing trash that is not the starting point
-trashCell = Cell {gameObject=Trash, background=EmptyBG}
+trashCell = Cell {gameObject = Trash, background = EmptyBG}
 
-emptystashCell :: Cell -- an empty stash
-emptystashCell = Cell {gameObject=Empty, background=Stash}
+stashCell :: Cell -- an empty stash
+stashCell = Cell {gameObject = Empty, background = Stash}
 
 -- level definitions
-sampleLevel :: Environment 
-sampleLevel = fromLists [[emptyCell , emptyCell     , wallCell       , emptyCell]
-                        ,[emptyCell , trashCell   , trashCell      , wallCell]
-                        ,[emptyCell, trashCell , trashCell , playerCell]
-                        ,[wallCell , wallCell     , wallCell       , emptyCell]
-                        ]
+sampleLevel :: Environment
+sampleLevel =
+  fromLists
+    [ [emptyCell, emptyCell, wallCell, emptyCell]
+    , [emptyCell, trashCell, trashCell, wallCell]
+    , [emptyCell, trashCell, trashCell, playerCell]
+    , [wallCell, wallCell, wallCell, emptyCell]
+    ]
 
 -- handle state change for motions
 move :: Movement -> Environment -> Environment
 move mv start =
-    case isVal of
-        ValidMov -> moveHelper mv loc start
-        InvalidMov -> start -- return same state since not valid move
-    where
-        loc = getPlayerLocation start
-        isVal = isValidMove mv loc start
+  case isVal of
+    ValidMov -> moveHelper mv loc start
+    InvalidMov -> start -- return same state since not valid move
+  where
+    loc = getPlayerLocation start
+    isVal = isValidMove mv loc start
 
 -- Moves the object at the given location within the given environment in the specified direction.
 -- Attempts to recursively move all pushable objects encountered by the initial move.
-moveHelper :: Movement -> Location -> Environment -> Environment 
+moveHelper :: Movement -> Location -> Environment -> Environment
 moveHelper mv fromLoc env = newEnv'
-    where 
-      toLoc = getLocationAfterMovement mv fromLoc  
-      fromElem = getCellAtLocation fromLoc env
-      toElem = getCellAtLocation toLoc env
+  where
+    toLoc = getLocationAfterMovement mv fromLoc
+    fromElem = getCellAtLocation fromLoc env
+    toElem = getCellAtLocation toLoc env
       -- The updated elements after performing the move:
       -- The backgrounds are currently kept the same.
-      -- The object in the from-location replaces the object in the to-location
-      fromElem' = Cell {gameObject=Empty, background=(background fromElem)}
-      toElem' = Cell {gameObject=(gameObject fromElem), background=(background toElem)}
+      -- The object in the from-location replaces the object in the to-location.
+      -- Trash should disappear if it is pushed into the stash
+    fromElem' = Cell {gameObject = Empty, background = (background fromElem)}
+    toElem' =
+      Cell
+        { gameObject =
+            (if (containsStash toLoc env)
+               then Empty
+               else gameObject fromElem)
+        , background = (background toElem)
+        }
       -- If the object previously occupying the to-location is pushable, attempt to move it recursively.
-      newEnv = if (gameObject toElem == Trash) then moveHelper mv toLoc env else env
-      newEnv' = setElem toElem' toLoc (setElem fromElem' fromLoc newEnv)
+    newEnv =
+      if (gameObject toElem == Trash)
+        then moveHelper mv toLoc env
+        else env
+    newEnv' = setElem toElem' toLoc (setElem fromElem' fromLoc newEnv)
+
+-- Returns True if the given location in the environment contains a stash; False otherwise.
+containsStash :: Location -> Environment -> Bool
+containsStash loc env = background (getCellAtLocation loc env) == Stash
 
 -- Returns the Cell at the given location in the environment.
-getCellAtLocation :: Location -> Environment -> Cell 
-getCellAtLocation (row, col) env = getElem row col env 
+getCellAtLocation :: Location -> Environment -> Cell
+getCellAtLocation (row, col) env = getElem row col env
 
 -- Returns a MoveStatus for the given movement with respect to the given location for the 
 -- current environment; ValidMov for valid moves, InvalidMov otherwise.
-isValidMove :: Movement -> Location -> Environment -> MoveStatus 
-isValidMove mv loc env = if boundsCheck then ValidMov else InvalidMov
-    where 
-        destLoc = getLocationAfterMovement mv loc  
-        destCell = getCellAtLocation destLoc env
-        boundsCheck = (isWithinEnvironment loc env) && 
-                      (isWithinEnvironment destLoc env) && 
-                      (not (containsWall destCell)) && 
-                      (not (containsPlayer destCell)) &&
-                      (containsEmptySpace destCell || (containsTrash destCell && (isValidMove mv destLoc env == ValidMov)))
-
+isValidMove :: Movement -> Location -> Environment -> MoveStatus
+isValidMove mv loc env =
+  if boundsCheck
+    then ValidMov
+    else InvalidMov
+  where
+    destLoc = getLocationAfterMovement mv loc
+    destCell = getCellAtLocation destLoc env
+    boundsCheck =
+      (isWithinEnvironment loc env) &&
+      (isWithinEnvironment destLoc env) &&
+      (not (containsWall destCell)) &&
+      (not (containsPlayer destCell)) &&
+      (containsEmptySpace destCell ||
+       (containsTrash destCell && (isValidMove mv destLoc env == ValidMov)))
 
 -- Returns True if the given location is within the environment; False otherwise.
-isWithinEnvironment :: Location -> Environment -> Bool 
-isWithinEnvironment (row, col) env = (Data.Ix.inRange rowRange row) && (Data.Ix.inRange colRange col)
-    where 
-        rowRange = (1, getNumRows env)
-        colRange = (1, getNumCols env)
+isWithinEnvironment :: Location -> Environment -> Bool
+isWithinEnvironment (row, col) env =
+  (Data.Ix.inRange rowRange row) && (Data.Ix.inRange colRange col)
+  where
+    rowRange = (1, getNumRows env)
+    colRange = (1, getNumCols env)
 
 -- Returns the Location that would result if the given Movement is applied to the current location.
-getLocationAfterMovement :: Movement -> Location -> Location 
+getLocationAfterMovement :: Movement -> Location -> Location
 getLocationAfterMovement UpMv (row, col) = (row - 1, col)
 getLocationAfterMovement RightMv (row, col) = (row, col + 1)
 getLocationAfterMovement DownMv (row, col) = (row + 1, col)
 getLocationAfterMovement LeftMv (row, col) = (row, col - 1)
 
 -- Returns True if the given Cell contains a Wall, False otherwise.
-containsWall :: Cell -> Bool 
-containsWall (Cell Wall _) = True 
+containsWall :: Cell -> Bool
+containsWall (Cell Wall _) = True
 containsWall _ = False
 
 -- Returns True if the given Cell contains a Player; False otherwise.
-containsPlayer :: Cell -> Bool 
-containsPlayer (Cell Player _) = True 
+containsPlayer :: Cell -> Bool
+containsPlayer (Cell Player _) = True
 containsPlayer _ = False
 
 -- Returns True if the given Cell contains an Empty space; False otherwise.
-containsEmptySpace :: Cell -> Bool 
-containsEmptySpace (Cell Empty _) = True 
+containsEmptySpace :: Cell -> Bool
+containsEmptySpace (Cell Empty _) = True
 containsEmptySpace _ = False
 
 -- Returns True if the given Cell contains a Trash; False otherwise.
-containsTrash :: Cell -> Bool 
-containsTrash (Cell Trash _) = True 
+containsTrash :: Cell -> Bool
+containsTrash (Cell Trash _) = True
 containsTrash _ = False
 
 -- Returns the (row, column) 1-based index of the player element in the given environment;
 -- if the player is not present, returns (-1, -1).
 getPlayerLocation :: Environment -> Location
-getPlayerLocation env = case findIndexMatrix env containsPlayer of 
-    Just location -> location 
+getPlayerLocation env =
+  case findIndexMatrix env containsPlayer of
+    Just location -> location
     Nothing -> (-1, -1)
 
 -- Returns the number of rows for the given rectangular matrix.
-getNumRows :: Matrix a -> Int 
+getNumRows :: Matrix a -> Int
 getNumRows mat = Data.Vector.length (getRow 1 mat)
 
 -- Returns the number of columns for the given rectangular matrix.
-getNumCols :: Matrix a -> Int 
+getNumCols :: Matrix a -> Int
 getNumCols mat = Data.Vector.length (getCol 1 mat)
 
 -- Returns the first-occuring index of an element within the matrix that satisfies the given predicate;
 -- Nothing if the element was not found.
 findIndexMatrix :: (Eq a) => Matrix a -> (a -> Bool) -> Maybe Location
-findIndexMatrix mat predicate = helper mat predicate (getNumRows mat) (getNumCols mat) 1 1
-    where 
-        helper :: (Eq a) => Matrix a -> (a -> Bool) -> Int -> Int -> Int -> Int -> Maybe Location
-        helper mat predicate numRows numCols row col
-            | row > numRows = Nothing -- reached end of matrix without finding desired element
-            | col > numCols = helper mat predicate numRows numCols (row + 1) 1 -- reached end of row
-            | predicate (getElem row col mat) = Just (row, col)
-            | otherwise = helper mat predicate numRows numCols row (col + 1)
+findIndexMatrix mat predicate =
+  helper mat predicate (getNumRows mat) (getNumCols mat) 1 1
+  where
+    helper ::
+         (Eq a)
+      => Matrix a
+      -> (a -> Bool)
+      -> Int
+      -> Int
+      -> Int
+      -> Int
+      -> Maybe Location
+    helper mat predicate numRows numCols row col
+      | row > numRows = Nothing -- reached end of matrix without finding desired element
+      | col > numCols = helper mat predicate numRows numCols (row + 1) 1 -- reached end of row
+      | predicate (getElem row col mat) = Just (row, col)
+      | otherwise = helper mat predicate numRows numCols row (col + 1)

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,3 +1,4 @@
+-- Tests for the game.
 module Main (main) where
 
 import Test.Tasty
@@ -17,15 +18,54 @@ tests = testGroup "Tests" [unitTests]
 level1 = Data.Matrix.fromLists [[emptyCell , emptyCell, wallCell  , emptyCell]
                                  ,[emptyCell , trashCell, trashCell , wallCell]
                                  ,[emptyCell , trashCell, playerCell, wallCell]
-                                 ,[wallCell  , wallCell , wallCell  , emptyCell]
+                                 ,[wallCell  , wallCell , emptyCell  , emptyCell]
                                  ]
 level1Loc = (3, 3)
 
-test1 = testCase "Movement to an empty cell" $ (isValidMove LeftMv level1Loc level1) @?= True
-test2 = testCase "Movement to a wall" $ (isValidMove RightMv level1Loc level1) @?= False
+level2 = Data.Matrix.fromLists [[emptyCell , emptyCell, wallCell]
+                                 ,[emptyCell , emptyCell, emptyCell]
+                                 ,[emptyCell , trashCell, playerCell]
+                                 ]
+level2Loc = (3, 3)
 
+level3 = Data.Matrix.fromLists [[emptyCell , emptyCell, emptyCell  , emptyCell, emptyCell]
+                                 ,[emptyCell , trashCell, trashCell , wallCell, emptyCell]
+                                 ,[emptyCell , trashCell, trashCell, wallCell, emptyCell]
+                                 ,[wallCell  , wallCell , playerCell  , emptyCell, emptyCell]
+                                 ,[wallCell  , wallCell , emptyCell  , emptyCell, emptyCell]
+                                 ]
+level3Loc = (4, 3)
+
+test1 = testCase "Validate movement to an empty cell" $ (isValidMove DownMv level1Loc level1) @?= ValidMov
+test2 = testCase "Validate movement to a wall" $ (isValidMove RightMv level1Loc level1) @?= InvalidMov
+test3 = testCase "Validate movement to a trash cell" $ (isValidMove LeftMv level1Loc level1) @?= ValidMov
+test4 = testCase "Move to an empty cell" $ (move UpMv level2) @?= Data.Matrix.fromLists [[emptyCell , emptyCell, wallCell]
+                                                                  ,[emptyCell , emptyCell, playerCell]
+                                                                  ,[emptyCell , trashCell, emptyCell]
+                                                                  ]
+test5 = testCase "Move and push a trash object" $ (move LeftMv level2) @?= Data.Matrix.fromLists [[emptyCell , emptyCell, wallCell]
+                                                                  ,[emptyCell , emptyCell, emptyCell]
+                                                                  ,[trashCell , playerCell, emptyCell]
+                                                                  ]
+test6 = testCase "Move out of bounds" $ (move DownMv level2) @?= level2
+test7 = testCase "Move into wall" $ (move LeftMv level3) @?= level3
+test8 = testCase "Recursive push" $ (move UpMv level3) @?= Data.Matrix.fromLists 
+                                [[emptyCell , emptyCell, trashCell  , emptyCell, emptyCell]
+                                 ,[emptyCell , trashCell, trashCell , wallCell, emptyCell]
+                                 ,[emptyCell , trashCell, playerCell, wallCell, emptyCell]
+                                 ,[wallCell  , wallCell , emptyCell  , emptyCell, emptyCell]
+                                 ,[wallCell  , wallCell , emptyCell  , emptyCell, emptyCell]
+                                 ]
+                              
+                                                                
 unitTests = testGroup "Unit tests"
   [ 
     test1,
-    test2
+    test2,
+    test3,
+    test4,
+    test5,
+    test6,
+    test7,
+    test8
   ]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,71 +1,136 @@
 -- Tests for the game.
-module Main (main) where
+module Main
+  ( main
+  ) where
 
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import Sokoban 
-import qualified Data.Matrix 
-
+import qualified Data.Matrix
+import Sokoban
 
 main :: IO ()
-main = defaultMain tests 
+main = defaultMain tests
 
 tests :: TestTree
 tests = testGroup "Tests" [unitTests]
 
+level1 =
+  Data.Matrix.fromLists
+    [ [emptyCell, emptyCell, wallCell, emptyCell]
+    , [emptyCell, trashCell, trashCell, wallCell]
+    , [emptyCell, trashCell, playerCell, wallCell]
+    , [wallCell, wallCell, emptyCell, emptyCell]
+    ]
 
-level1 = Data.Matrix.fromLists [[emptyCell , emptyCell, wallCell  , emptyCell]
-                                 ,[emptyCell , trashCell, trashCell , wallCell]
-                                 ,[emptyCell , trashCell, playerCell, wallCell]
-                                 ,[wallCell  , wallCell , emptyCell  , emptyCell]
-                                 ]
 level1Loc = (3, 3)
 
-level2 = Data.Matrix.fromLists [[emptyCell , emptyCell, wallCell]
-                                 ,[emptyCell , emptyCell, emptyCell]
-                                 ,[emptyCell , trashCell, playerCell]
-                                 ]
+level2 =
+  Data.Matrix.fromLists
+    [ [emptyCell, emptyCell, wallCell]
+    , [emptyCell, emptyCell, emptyCell]
+    , [emptyCell, trashCell, playerCell]
+    ]
+
 level2Loc = (3, 3)
 
-level3 = Data.Matrix.fromLists [[emptyCell , emptyCell, emptyCell  , emptyCell, emptyCell]
-                                 ,[emptyCell , trashCell, trashCell , wallCell, emptyCell]
-                                 ,[emptyCell , trashCell, trashCell, wallCell, emptyCell]
-                                 ,[wallCell  , wallCell , playerCell  , emptyCell, emptyCell]
-                                 ,[wallCell  , wallCell , emptyCell  , emptyCell, emptyCell]
-                                 ]
+level3 =
+  Data.Matrix.fromLists
+    [ [emptyCell, emptyCell, emptyCell, emptyCell, emptyCell]
+    , [emptyCell, trashCell, trashCell, wallCell, emptyCell]
+    , [emptyCell, trashCell, trashCell, wallCell, emptyCell]
+    , [wallCell, wallCell, playerCell, emptyCell, emptyCell]
+    , [wallCell, wallCell, emptyCell, emptyCell, emptyCell]
+    ]
+
 level3Loc = (4, 3)
 
-test1 = testCase "Validate movement to an empty cell" $ (isValidMove DownMv level1Loc level1) @?= ValidMov
-test2 = testCase "Validate movement to a wall" $ (isValidMove RightMv level1Loc level1) @?= InvalidMov
-test3 = testCase "Validate movement to a trash cell" $ (isValidMove LeftMv level1Loc level1) @?= ValidMov
-test4 = testCase "Move to an empty cell" $ (move UpMv level2) @?= Data.Matrix.fromLists [[emptyCell , emptyCell, wallCell]
-                                                                  ,[emptyCell , emptyCell, playerCell]
-                                                                  ,[emptyCell , trashCell, emptyCell]
-                                                                  ]
-test5 = testCase "Move and push a trash object" $ (move LeftMv level2) @?= Data.Matrix.fromLists [[emptyCell , emptyCell, wallCell]
-                                                                  ,[emptyCell , emptyCell, emptyCell]
-                                                                  ,[trashCell , playerCell, emptyCell]
-                                                                  ]
+level4 =
+  Data.Matrix.fromLists
+    [ [emptyCell, emptyCell, wallCell]
+    , [emptyCell, emptyCell, emptyCell]
+    , [stashCell, trashCell, playerCell]
+    ]
+
+level4Loc = (3, 3)
+
+level5 =
+  Data.Matrix.fromLists
+    [ [emptyCell, emptyCell, playerCell, emptyCell, emptyCell]
+    , [emptyCell, trashCell, trashCell, wallCell, emptyCell]
+    , [emptyCell, trashCell, trashCell, wallCell, emptyCell]
+    , [wallCell, wallCell, stashCell, emptyCell, emptyCell]
+    , [wallCell, wallCell, emptyCell, emptyCell, emptyCell]
+    ]
+
+level5Loc = (1, 3)
+
+test1 =
+  testCase "Validate movement to an empty cell" $
+  (isValidMove DownMv level1Loc level1) @?= ValidMov
+
+test2 =
+  testCase "Validate movement to a wall" $
+  (isValidMove RightMv level1Loc level1) @?= InvalidMov
+
+test3 =
+  testCase "Validate movement to a trash cell" $
+  (isValidMove LeftMv level1Loc level1) @?= ValidMov
+
+test4 =
+  testCase "Move to an empty cell" $
+  (move UpMv level2) @?=
+  Data.Matrix.fromLists
+    [ [emptyCell, emptyCell, wallCell]
+    , [emptyCell, emptyCell, playerCell]
+    , [emptyCell, trashCell, emptyCell]
+    ]
+
+test5 =
+  testCase "Move and push a trash object" $
+  (move LeftMv level2) @?=
+  Data.Matrix.fromLists
+    [ [emptyCell, emptyCell, wallCell]
+    , [emptyCell, emptyCell, emptyCell]
+    , [trashCell, playerCell, emptyCell]
+    ]
+
 test6 = testCase "Move out of bounds" $ (move DownMv level2) @?= level2
+
 test7 = testCase "Move into wall" $ (move LeftMv level3) @?= level3
-test8 = testCase "Recursive push" $ (move UpMv level3) @?= Data.Matrix.fromLists 
-                                [[emptyCell , emptyCell, trashCell  , emptyCell, emptyCell]
-                                 ,[emptyCell , trashCell, trashCell , wallCell, emptyCell]
-                                 ,[emptyCell , trashCell, playerCell, wallCell, emptyCell]
-                                 ,[wallCell  , wallCell , emptyCell  , emptyCell, emptyCell]
-                                 ,[wallCell  , wallCell , emptyCell  , emptyCell, emptyCell]
-                                 ]
-                              
-                                                                
-unitTests = testGroup "Unit tests"
-  [ 
-    test1,
-    test2,
-    test3,
-    test4,
-    test5,
-    test6,
-    test7,
-    test8
-  ]
+
+test8 =
+  testCase "Recursive push" $
+  (move UpMv level3) @?=
+  Data.Matrix.fromLists
+    [ [emptyCell, emptyCell, trashCell, emptyCell, emptyCell]
+    , [emptyCell, trashCell, trashCell, wallCell, emptyCell]
+    , [emptyCell, trashCell, playerCell, wallCell, emptyCell]
+    , [wallCell, wallCell, emptyCell, emptyCell, emptyCell]
+    , [wallCell, wallCell, emptyCell, emptyCell, emptyCell]
+    ]
+
+test9 =
+  testCase "Push trash into stash" $
+  (move LeftMv level4) @?=
+  Data.Matrix.fromLists
+    [ [emptyCell, emptyCell, wallCell]
+    , [emptyCell, emptyCell, emptyCell]
+    , [stashCell, playerCell, emptyCell]
+    ]
+
+test10 =
+  testCase "Recursive push of trash into stash" $
+  (move DownMv level5) @?=
+  Data.Matrix.fromLists
+    [ [emptyCell, emptyCell, emptyCell, emptyCell, emptyCell]
+    , [emptyCell, trashCell, playerCell, wallCell, emptyCell]
+    , [emptyCell, trashCell, trashCell, wallCell, emptyCell]
+    , [wallCell, wallCell, stashCell, emptyCell, emptyCell]
+    , [wallCell, wallCell, emptyCell, emptyCell, emptyCell]
+    ]
+
+unitTests =
+  testGroup
+    "Unit tests"
+    [test1, test2, test3, test4, test5, test6, test7, test8, test9, test10]


### PR DESCRIPTION
Implements recursive pushing for trash objects. Each movement, not only the initial one, is treated as something that can initiate the movement of other objects. Pushing only happens in one direction; there is no circular pushing.

I deleted the code that distinguished between pushing and moving, since with recursive pushing, there is no longer a need to distinguish between them to implement movement.

This PR also handles the disappearing of trash when it is pushed onto a stash cell. Currently the game doesn't maintain any state to track the number of trash objects left; this can be added later to facilitate checking when a level is complete.

Compiled and built code; verified that terminal program works; all tests pass.