### PR TITLE
:sparkles: Add Level Select screen and logic along with Resetting Level Logic

### DIFF
--- a/cse230-project.cabal
+++ b/cse230-project.cabal
@@ -14,7 +14,8 @@ cabal-version:       >=1.10
 library
   ghc-options:        -W
   exposed-modules:     Sokoban,
-                       Game
+                       Game,
+                       LevelSelect
   build-depends:       base,
                        brick,
                        matrix,

--- a/src/Game.hs
+++ b/src/Game.hs
@@ -34,7 +34,8 @@ app = App
   }
 
 -- Apply a function to a level's environment
-applyMoveLevel f lvl = (fst lvl, f (snd lvl))
+applyMoveLevel ::  (Environment -> Environment) -> Level -> Level
+applyMoveLevel f lvl = MkLevel {levelNum = levelNum lvl, env = f (env lvl)}
 
 handleEvent :: Level -> BrickEvent Name e -> EventM Name (Next Level)
 -- (Esc, q) key to quit
@@ -66,7 +67,7 @@ attributes = attrMap V.defAttr [(attrName "player", fg V.cyan)]
 drawGrid :: Level -> [Widget Name]
 drawGrid lvl = [renderTable (setDefaultRowAlignment AlignMiddle $
     setDefaultColAlignment AlignCenter $
-    convertMap2Table (snd lvl))]
+    convertMap2Table (env lvl))]
 
 
 cell2string Player = "P"

--- a/src/LevelSelect.hs
+++ b/src/LevelSelect.hs
@@ -41,13 +41,13 @@ ui =
 ---- Level Definitions
 -- Empty Level
 empty_lvl :: Level
-empty_lvl = (-1, empty_lvl_env)
+empty_lvl = MkLevel {levelNum=(-1), env=empty_lvl_env}
 empty_lvl_env :: Environment
 empty_lvl_env = Data.Matrix.fromLists [[playerCell]]
 
 -- Level 0
 level_0 :: Level
-level_0 = (0, level_0_env)
+level_0 = MkLevel {levelNum=(0), env=level_0_env}
 level_0_env :: Environment
 level_0_env = Data.Matrix.fromLists [[emptyCell , emptyCell     , wallCell       , emptyCell]
                         ,[emptyCell , trashCell   , trashCell      , wallCell]
@@ -57,7 +57,7 @@ level_0_env = Data.Matrix.fromLists [[emptyCell , emptyCell     , wallCell      
 
 -- Level 1
 level_1 :: Level
-level_1 = (1, level_1_env)
+level_1 = MkLevel {levelNum=(1), env=level_1_env}
 level_1_env :: Environment
 level_1_env = Data.Matrix.fromLists [[trashCell , trashCell     , wallCell       , emptyCell]
                         ,[emptyCell , trashCell   , trashCell      , wallCell]
@@ -67,7 +67,7 @@ level_1_env = Data.Matrix.fromLists [[trashCell , trashCell     , wallCell      
 
 -- Level 2
 level_2 :: Level
-level_2 = (2, level_2_env)
+level_2 = MkLevel {levelNum=(2), env=level_2_env}
 level_2_env :: Environment
 level_2_env = Data.Matrix.fromLists [[wallCell , wallCell     , wallCell       , emptyCell]
                         ,[emptyCell , trashCell   , trashCell      , wallCell]
@@ -98,7 +98,7 @@ levelSelect = defaultMain app empty_lvl
 -- Resets level to its original start position
 resetLevel :: Level -> Level
 resetLevel lvl =
-    case (fst lvl) of
+    case (levelNum lvl) of
         0 -> level_0
         1 -> level_1
         2 -> level_2

--- a/src/LevelSelect.hs
+++ b/src/LevelSelect.hs
@@ -2,7 +2,8 @@
 module LevelSelect
 (
     levelSelect,
-    resetLevel
+    resetLevel,
+    max_level
 )
     where
 import Sokoban
@@ -39,15 +40,17 @@ ui =
     $ foldl (<=>) (str "Level Select:") levels_list
 
 ---- Level Definitions
+max_level :: Int
+max_level = 2
 -- Empty Level
 empty_lvl :: Level
-empty_lvl = MkLevel {levelNum=(-1), env=empty_lvl_env}
+empty_lvl = MkLevel {levelNum=(-1), env=empty_lvl_env, exit=False}
 empty_lvl_env :: Environment
 empty_lvl_env = Data.Matrix.fromLists [[playerCell]]
 
 -- Level 0
 level_0 :: Level
-level_0 = MkLevel {levelNum=(0), env=level_0_env}
+level_0 = MkLevel {levelNum=(0), env=level_0_env, exit=False}
 level_0_env :: Environment
 level_0_env = Data.Matrix.fromLists [[emptyCell , emptyCell     , wallCell       , emptyCell]
                         ,[emptyCell , trashCell   , trashCell      , wallCell]
@@ -57,7 +60,7 @@ level_0_env = Data.Matrix.fromLists [[emptyCell , emptyCell     , wallCell      
 
 -- Level 1
 level_1 :: Level
-level_1 = MkLevel {levelNum=(1), env=level_1_env}
+level_1 = MkLevel {levelNum=(1), env=level_1_env, exit=False}
 level_1_env :: Environment
 level_1_env = Data.Matrix.fromLists [[trashCell , trashCell     , wallCell       , emptyCell]
                         ,[emptyCell , trashCell   , trashCell      , wallCell]
@@ -67,7 +70,7 @@ level_1_env = Data.Matrix.fromLists [[trashCell , trashCell     , wallCell      
 
 -- Level 2
 level_2 :: Level
-level_2 = MkLevel {levelNum=(2), env=level_2_env}
+level_2 = MkLevel {levelNum=(2), env=level_2_env, exit=False}
 level_2_env :: Environment
 level_2_env = Data.Matrix.fromLists [[wallCell , wallCell     , wallCell       , emptyCell]
                         ,[emptyCell , trashCell   , trashCell      , wallCell]

--- a/src/LevelSelect.hs
+++ b/src/LevelSelect.hs
@@ -1,0 +1,105 @@
+-- Level Select and various Levels
+module LevelSelect
+(
+    levelSelect,
+    resetLevel
+)
+    where
+import Sokoban
+import Brick
+import qualified Brick.Widgets.Border as B
+import qualified Brick.Widgets.Border.Style as BS
+import qualified Brick.Widgets.Center as C
+import qualified Graphics.Vty as V
+
+import qualified Data.Matrix
+
+type Name = ()
+
+app :: App Level e Name
+app = App
+  { appDraw         = const [ui]
+  , appHandleEvent  = handleEvent
+  , appStartEvent   = return
+  , appAttrMap      = const $ attrMap V.defAttr []
+  , appChooseCursor = neverShowCursor
+  }
+
+-- Level Select List for Display
+levels = ["Level 0", "Level 1", "Level 2"]
+concat_bullet = ("-" ++)
+levels_list = map str (map (concat_bullet) levels)
+
+-- Level Select UI
+ui :: Widget ()
+ui =
+    C.center
+    $ withBorderStyle BS.unicodeBold
+    $ B.borderWithLabel (str "Raccoon Rush")
+    $ foldl (<=>) (str "Level Select:") levels_list
+
+---- Level Definitions
+-- Empty Level
+empty_lvl :: Level
+empty_lvl = (-1, empty_lvl_env)
+empty_lvl_env :: Environment
+empty_lvl_env = Data.Matrix.fromLists [[playerCell]]
+
+-- Level 0
+level_0 :: Level
+level_0 = (0, level_0_env)
+level_0_env :: Environment
+level_0_env = Data.Matrix.fromLists [[emptyCell , emptyCell     , wallCell       , emptyCell]
+                        ,[emptyCell , trashCell   , trashCell      , wallCell]
+                        ,[emptyCell, trashCell , playerCell , wallCell]
+                        ,[wallCell , wallCell     , wallCell       , emptyCell]
+                        ]
+
+-- Level 1
+level_1 :: Level
+level_1 = (1, level_1_env)
+level_1_env :: Environment
+level_1_env = Data.Matrix.fromLists [[trashCell , trashCell     , wallCell       , emptyCell]
+                        ,[emptyCell , trashCell   , trashCell      , wallCell]
+                        ,[emptyCell, trashCell , playerCell , wallCell]
+                        ,[wallCell , wallCell     , wallCell       , emptyCell]
+                        ]
+
+-- Level 2
+level_2 :: Level
+level_2 = (2, level_2_env)
+level_2_env :: Environment
+level_2_env = Data.Matrix.fromLists [[wallCell , wallCell     , wallCell       , emptyCell]
+                        ,[emptyCell , trashCell   , trashCell      , wallCell]
+                        ,[emptyCell, trashCell , playerCell , wallCell]
+                        ,[wallCell , wallCell     , wallCell       , emptyCell]
+                        ]
+
+-- Event Handling for Level Select Screen
+handleEvent :: Level -> BrickEvent () e -> EventM Name (Next Level)
+-- Exiting Level Select
+handleEvent env (VtyEvent (V.EvKey V.KEsc [])) = halt env
+handleEvent env (VtyEvent (V.EvKey (V.KChar 'q') [])) = halt env
+-- Level Select Event
+handleEvent env (VtyEvent (V.EvKey (V.KChar d) [])) =
+  if d `elem` ['0' .. '2'] then
+    do
+        case read [d] of
+            0 -> halt $ level_0
+            1 -> halt $ level_1
+            2 -> halt $ level_2
+            _ -> continue env
+  else continue env
+handleEvent env _                              = continue env
+
+-- Level Select Screen
+levelSelect = defaultMain app empty_lvl
+
+-- Resets level to its original start position
+resetLevel :: Level -> Level
+resetLevel lvl =
+    case (fst lvl) of
+        0 -> level_0
+        1 -> level_1
+        2 -> level_2
+        _ -> empty_lvl

--- a/src/Sokoban.hs
+++ b/src/Sokoban.hs
@@ -4,6 +4,7 @@ module Sokoban
     GameObject(..),
     Background(..),
     Cell(..),
+    Level,
     Environment,
     Movement(..),
     move,
@@ -35,6 +36,9 @@ data Cell = MkCell {
     background :: Background
 }
     deriving (Eq, Show)
+
+-- Level number and its environment
+type Level = (Int, Environment)
 
 -- The representation of an individual level
 type Environment = Matrix Cell

--- a/src/Sokoban.hs
+++ b/src/Sokoban.hs
@@ -4,7 +4,7 @@ module Sokoban
     GameObject(..),
     Background(..),
     Cell(..),
-    Level,
+    Level(..),
     Environment,
     Movement(..),
     move,
@@ -38,7 +38,12 @@ data Cell = MkCell {
     deriving (Eq, Show)
 
 -- Level number and its environment
-type Level = (Int, Environment)
+data Level = MkLevel {
+    levelNum :: Int,
+    env :: Environment
+}
+
+-- type Level = (Int, Environment)
 
 -- The representation of an individual level
 type Environment = Matrix Cell

--- a/src/Sokoban.hs
+++ b/src/Sokoban.hs
@@ -40,7 +40,8 @@ data Cell = MkCell {
 -- Level number and its environment
 data Level = MkLevel {
     levelNum :: Int,
-    env :: Environment
+    env :: Environment,
+    exit :: Bool
 }
 
 -- type Level = (Int, Environment)


### PR DESCRIPTION
Add 'LevelSelect.hs' which handles level select screen ui and logic
- Reset Level logic here  

Added new type 'Level' :: (Int, Environment) in 'Sokoban.hs'.
Restructure event handling in 'Game.hs' to use 'Level' instead of 'Environment' for resetting level logic

Compiles and runs properly (no automated tests run)